### PR TITLE
Get correct LocatedFileStatus modification_time for Objects when fs.listFiles called 

### DIFF
--- a/hdfs-connector/src/main/java/com/oracle/bmc/hdfs/store/BmcDataStore.java
+++ b/hdfs-connector/src/main/java/com/oracle/bmc/hdfs/store/BmcDataStore.java
@@ -851,7 +851,7 @@ public class BmcDataStore {
                 this.isDirectory(summary),
                 BLOCK_REPLICATION,
                 this.blockSizeInBytes,
-                summary.getTimeModified() == null ? summary.getTimeCreated().getTime() : summary.getTimeModified().getTime(),
+                summary.getTimeModified().getTime(),
                 this.objectToPath(parentPath, summary.getName()));
     }
 

--- a/hdfs-connector/src/main/java/com/oracle/bmc/hdfs/store/BmcDataStore.java
+++ b/hdfs-connector/src/main/java/com/oracle/bmc/hdfs/store/BmcDataStore.java
@@ -851,7 +851,7 @@ public class BmcDataStore {
                 this.isDirectory(summary),
                 BLOCK_REPLICATION,
                 this.blockSizeInBytes,
-                summary.getTimeCreated().getTime(),
+                summary.getTimeModified() == null ? summary.getTimeCreated().getTime() : summary.getTimeModified().getTime(),
                 this.objectToPath(parentPath, summary.getName()));
     }
 

--- a/hdfs-connector/src/main/java/com/oracle/bmc/hdfs/store/RequestBuilder.java
+++ b/hdfs-connector/src/main/java/com/oracle/bmc/hdfs/store/RequestBuilder.java
@@ -35,7 +35,7 @@ import org.apache.hadoop.util.StopWatch;
 @RequiredArgsConstructor(access = AccessLevel.PACKAGE)
 class RequestBuilder {
     // TODO: these fields should ideally come from the SDK.
-    private static final String SIZE_AND_TIME_FILDS = "size,timeCreated";
+    private static final String SIZE_AND_TIME_FILDS = "size,timeCreated,timeModified";
 
     private final String namespace;
     private final String bucket;


### PR DESCRIPTION
In `BmcDataStore.createFileStatus`, the timeCreated was used in the place for timeModified, which caused the LocatedFileStatus to have wrong modification_time when objects are overwritten in OCI Object Storage. 

It turns out that in the RequestBuilder, the `timeModified` was never included in the original request to OCI Object Storage. This caused the returned ObjectSummary contains timeModified as `null`, so need to add the field in the request

Signed-off-by: Kevin Wen <kevinwen@gmail.com>