### PR TITLE
Releasing version 3.3.4.1.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
+## 3.3.4.1.5.1 - 2024-08-27
+### Changed
+-  Updated commons-compress from `1.21` to `1.26.0`,  CVE-2024-26308
+### Added
+-  Added jettison as dependency for HDFS-connector fat jar
+-  Added SECURITY.md
+
 ## 3.3.4.1.5.0 - 2024-06-17
 ### Changed
 -  Updated OCI Java SDK version to `3.39.0`

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,38 @@
+# Reporting security vulnerabilities
+
+Oracle values the independent security research community and believes that
+responsible disclosure of security vulnerabilities helps us ensure the security
+and privacy of all our users.
+
+Please do NOT raise a GitHub Issue to report a security vulnerability. If you
+believe you have found a security vulnerability, please submit a report to
+[secalert_us@oracle.com][1] preferably with a proof of concept. Please review
+some additional information on [how to report security vulnerabilities to Oracle][2].
+We encourage people who contact Oracle Security to use email encryption using
+[our encryption key][3].
+
+We ask that you do not use other channels or contact the project maintainers
+directly.
+
+Non-vulnerability related security issues including ideas for new or improved
+security features are welcome on GitHub Issues.
+
+## Security updates, alerts and bulletins
+
+Security updates will be released on a regular cadence. Many of our projects
+will typically release security fixes in conjunction with the
+Oracle Critical Patch Update program. Additional
+information, including past advisories, is available on our [security alerts][4]
+page.
+
+## Security-related information
+
+We will provide security related information such as a threat model, considerations
+for secure use, or any known security issues in our documentation. Please note
+that labs and sample code are intended to demonstrate a concept and may not be
+sufficiently hardened for production use.
+
+[1]: mailto:secalert_us@oracle.com
+[2]: https://www.oracle.com/corporate/security-practices/assurance/vulnerability/reporting.html
+[3]: https://www.oracle.com/security-alerts/encryptionkey.html
+[4]: https://www.oracle.com/security-alerts/

--- a/hdfs-addons/hdfs-smartparquet/pom.xml
+++ b/hdfs-addons/hdfs-smartparquet/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <artifactId>oci-hdfs-addons</artifactId>
         <groupId>com.oracle.oci.sdk</groupId>
-        <version>3.3.4.1.5.0</version>
+        <version>3.3.4.1.5.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -149,7 +149,7 @@
         <dependency>
             <groupId>com.oracle.oci.sdk</groupId>
             <artifactId>oci-hdfs-connector</artifactId>
-            <version>3.3.4.1.5.0</version>
+            <version>3.3.4.1.5.1</version>
         </dependency>
         <dependency>
             <groupId>org.apache.hadoop</groupId>
@@ -251,7 +251,7 @@
         <dependency>
             <groupId>com.oracle.oci.sdk</groupId>
             <artifactId>oci-hdfs-connector</artifactId>
-            <version>3.3.4.1.5.0</version>
+            <version>3.3.4.1.5.1</version>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>

--- a/hdfs-addons/pom.xml
+++ b/hdfs-addons/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <artifactId>oci-hdfs</artifactId>
         <groupId>com.oracle.oci.sdk</groupId>
-        <version>3.3.4.1.5.0</version>
+        <version>3.3.4.1.5.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/hdfs-connector/pom.xml
+++ b/hdfs-connector/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-hdfs</artifactId>
-    <version>3.3.4.1.5.0</version>
+    <version>3.3.4.1.5.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -222,6 +222,11 @@
       <artifactId>powermock-api-mockito</artifactId>
       <version>${powermock.version}</version>
       <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.codehaus.jettison</groupId>
+      <artifactId>jettison</artifactId>
+      <version>1.5.4</version>
     </dependency>
     <dependency>
       <groupId>org.apache.hadoop</groupId>

--- a/hdfs-example/pom.xml
+++ b/hdfs-example/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-hdfs</artifactId>
-    <version>3.3.4.1.5.0</version>
+    <version>3.3.4.1.5.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -82,7 +82,7 @@
     <dependency>
         <groupId>com.oracle.oci.sdk</groupId>
         <artifactId>oci-hdfs-connector</artifactId>
-        <version>3.3.4.1.5.0</version>
+        <version>3.3.4.1.5.1</version>
     </dependency>
     <!-- For setting up an HTTP proxy -->
     <dependency>

--- a/hdfs-full/pom.xml
+++ b/hdfs-full/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>com.oracle.oci.sdk</groupId>
     <artifactId>oci-hdfs</artifactId>
-    <version>3.3.4.1.5.0</version>
+    <version>3.3.4.1.5.1</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -143,7 +143,7 @@
           <artifactId>oci-hdfs-addons-smartparquet</artifactId>
           <type>zip</type>
           <classifier>release</classifier>
-          <version>3.3.4.1.5.0</version>
+          <version>3.3.4.1.5.1</version>
           <exclusions>
             <exclusion>
               <groupId>org.apache.hadoop</groupId>
@@ -181,6 +181,10 @@
                 <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
               </transformers>
               <relocations>
+                <relocation>
+                  <pattern>org.codehaus.jettison</pattern>
+                  <shadedPattern>shaded.oracle.org.codehaus.jettison</shadedPattern>
+                </relocation>
                 <relocation>
                   <pattern>org.apache.http</pattern>
                   <shadedPattern>shaded.oracle.org.apache.http</shadedPattern>
@@ -323,7 +327,7 @@
     <dependency>
       <groupId>com.oracle.oci.sdk</groupId>
       <artifactId>oci-hdfs-connector</artifactId>
-      <version>3.3.4.1.5.0</version>
+      <version>3.3.4.1.5.1</version>
       <!-- We don't want to bundle any hadoop packages -->
       <exclusions>
         <exclusion>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
   <groupId>com.oracle.oci.sdk</groupId>
   <artifactId>oci-hdfs</artifactId>
-  <version>3.3.4.1.5.0</version>
+  <version>3.3.4.1.5.1</version>
   <packaging>pom</packaging>
 
   <name>Oracle Cloud Infrastructure HDFS Connector for Storage Service</name>
@@ -337,7 +337,7 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-compress</artifactId>
-      <version>1.21</version>
+      <version>1.26.0</version>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
## 3.3.4.1.5.1 - 2024-08-27
### Changed
-  Updated commons-compress from `1.21` to `1.26.0`,  CVE-2024-26308
### Added
-  Added jettison as dependency for HDFS-connector fat jar
-  Added SECURITY.md