### PR TITLE
Better Handle BmcFileSystemImpl Close & Cache Invalidate to prevent thread leak

### DIFF
--- a/hdfs-connector/src/main/java/com/oracle/bmc/hdfs/store/BmcDataStore.java
+++ b/hdfs-connector/src/main/java/com/oracle/bmc/hdfs/store/BmcDataStore.java
@@ -98,7 +98,7 @@ import org.apache.hadoop.util.Progressable;
  * Statistics are updated only on successful operations, and not on attempted operations.
  */
 @Slf4j
-public class BmcDataStore {
+public class BmcDataStore implements AutoCloseable{
     private static final int ERROR_CODE_FILE_EXISTS = 412;
 
     private static final int MiB = 1024 * 1024;
@@ -109,7 +109,11 @@ public class BmcDataStore {
     // TODO: need to get last modified date (creation date for objects) in some missing cases
     private static final long LAST_MODIFICATION_TIME = 0L;
 
+    private static final long TIMEOUT_EXECUTOR_SHUTDOWN = 600L ;
+
     private static final TimeUnit THREAD_KEEP_ALIVE_TIME_UNIT = TimeUnit.SECONDS;
+
+    private static final TimeUnit TIME_UNIT_EXECUTOR_SHUTDOWN = TimeUnit.SECONDS;
 
     private final ObjectStorage objectStorage;
     private final Statistics statistics;
@@ -780,6 +784,37 @@ public class BmcDataStore {
             renameResponses.add(new RenameResponse(objectToRename, newObjectName, futureResponse));
         }
         awaitRenameOperationTermination(renameResponses);
+    }
+
+    @Override
+    public void close() {
+        /*
+        To close the executor Services to avoid thread leaking causing OOM
+         */
+        closeExecutorService(this.parallelDownloadExecutor, TIMEOUT_EXECUTOR_SHUTDOWN, TIME_UNIT_EXECUTOR_SHUTDOWN);
+        closeExecutorService(this.parallelUploadExecutor, TIMEOUT_EXECUTOR_SHUTDOWN, TIME_UNIT_EXECUTOR_SHUTDOWN);
+        closeExecutorService(this.parallelRenameExecutor, TIMEOUT_EXECUTOR_SHUTDOWN, TIME_UNIT_EXECUTOR_SHUTDOWN);
+        closeExecutorService(this.parallelMd5executor, TIMEOUT_EXECUTOR_SHUTDOWN, TIME_UNIT_EXECUTOR_SHUTDOWN);
+    }
+
+    private void closeExecutorService(ExecutorService executorService,long timeOut,TimeUnit timeUnitOfTimeout) {
+        executorService.shutdown();
+        try {
+            if (!executorService.awaitTermination(timeOut, timeUnitOfTimeout)) {
+                LOG.warn("ExecutorService did not terminate within the specified timeout {} {}",timeOut,timeUnitOfTimeout);
+            }
+        } catch (InterruptedException e) {
+            LOG.error("Current Thread was interrupted while awaiting termination of ExecutorService.", e);
+            /* set back the interrupt status .
+            Ref : https://docs.oracle.com/javase/tutorial/essential/concurrency/interrupt.html */
+            Thread.currentThread().interrupt();
+        } finally {
+            // In both cases (timeout or interrupted), force shutdown
+            if (!executorService.isTerminated()) {
+                LOG.warn("Forcing shutdown of ExecutorService by sending interrupt to threads in Exec service ");
+                executorService.shutdownNow();
+            }
+        }
     }
 
     @RequiredArgsConstructor

--- a/hdfs-connector/src/main/java/com/oracle/bmc/hdfs/store/BmcDataStore.java
+++ b/hdfs-connector/src/main/java/com/oracle/bmc/hdfs/store/BmcDataStore.java
@@ -798,6 +798,10 @@ public class BmcDataStore implements AutoCloseable{
     }
 
     private void closeExecutorService(ExecutorService executorService,long timeOut,TimeUnit timeUnitOfTimeout) {
+        if (executorService == null) {
+            LOG.debug("ExecutorService is null, skipping shutdown");
+            return;
+        }
         executorService.shutdown();
         try {
             if (!executorService.awaitTermination(timeOut, timeUnitOfTimeout)) {


### PR DESCRIPTION
Fixes : https://github.com/oracle/oci-hdfs-connector/issues/109 

When debugging the thread leak we were able to see the executorService which creates the threads are not shutdown when closing, which can lead to this issue. 

Good Read about this : [MEMORY LEAK IN JAVA EXECUTOR! - GC easy](https://blog.gceasy.io/memory-leak-in-java-executor/) 

However attempting to close the executorService Instances in `BmcFileSystemImpl` close, had another problem with cache invalidation logic. 


### Problem With Cache invalidation
The current cache size is set as 0 with the cache disabled and in the removal listener we are closing the `BmcFileSystemImpl` , so the `ExecutorService` also gets closed even at the creation, leading to not being able to make operations. 

#### Will this issue ( ExecService close at creation )  exist if the cache is enabled?
With cache enabled, we’ll hit this issue once evicting the `BmcFileSystemImpl` & in the process of closing if we close the ExecService. So enabling caching is not a solution to avoid this issue 

#### How this did not affect till now? 
We are using the closed `BmcFileSystemImpl` , as the Executor service is open we are able to make I/O calls using the underlying threads ( this only has `null` check & not `isClosed()` check - This PR fixes this as well ) 

### Anti Pattern of child Object clearing all the holding ( parent)  objects
At `BmcFileSystemImpl.close()` we can see it closes all the Objects `BmcFileSystem`'s which are holding the implementations . This causes problems to the clients which hold that . 


cc : @yanhaizhongyu
