### PR TITLE
Make timeouts of core threads instead of having them fixed open for BmcDataStore

### DIFF
--- a/hdfs-connector/src/main/java/com/oracle/bmc/hdfs/BmcConstants.java
+++ b/hdfs-connector/src/main/java/com/oracle/bmc/hdfs/BmcConstants.java
@@ -43,6 +43,8 @@ public final class BmcConstants {
 
     public static final String NUM_READ_AHEAD_THREADS_KEY = "fs.oci.io.read.ahead.numthreads";
 
+    public static final String DATASTORE_IO_THREAD_TIMEOUT_IN_SECONDS_KEY = "fs.oci.io.threads.timeout.seconds";
+
     public static final String WRITE_STREAM_CLASS_KEY = "fs.oci.io.write.custom.stream";
 
     public static final String OBJECT_STORE_CLIENT_CLASS_KEY = "fs.oci.client.custom.client";

--- a/hdfs-connector/src/main/java/com/oracle/bmc/hdfs/BmcProperties.java
+++ b/hdfs-connector/src/main/java/com/oracle/bmc/hdfs/BmcProperties.java
@@ -331,6 +331,14 @@ public enum BmcProperties {
      */
     NUM_READ_AHEAD_THREADS(NUM_READ_AHEAD_THREADS_KEY, 16),
 
+
+    /**
+     * (long,optional) Timeout for the I/O threads created to make operations to the Object Storage service.
+     * See {@link BmcConstants#DATASTORE_IO_THREAD_TIMEOUT_IN_SECONDS_KEY} for config key name. Default is 10 minutes.
+     * Smaller than or equal to 0 is interpreted as using the default value.
+     */
+    BMC_DATASTORE_IO_THREAD_TIMEOUT_IN_SECONDS(DATASTORE_IO_THREAD_TIMEOUT_IN_SECONDS_KEY,600L),
+
     /**
      * (boolean, optional) When set to true, enforces strict directory marker rules for the file system represented by the Object Storage bucket.
      * Each directory must be represented by a zero-byte object with the (directory name + '/') as the object name.


### PR DESCRIPTION
Fixes : https://github.com/oracle/oci-hdfs-connector/issues/109

This allows the parked core threads to be timeout.

The tradeoff is when old threads are closed, creating new threads will take a very fractional time  compared to keeping them parked always leading to OOM

This fix is more of a hot fix , however having this along with https://github.com/oracle/oci-hdfs-connector/pull/110 fixes this issues better

More Ref : 

- https://stackoverflow.com/questions/18225673/what-is-the-use-of-allowcorethreadtimeout-in-threadpoolexecutor
-  https://stackoverflow.com/questions/55879100/with-threadpoolexecutor-what-is-the-difference-between-allowcorethreadtimeout-a

