### PR TITLE
option to Disabling circuit breaker in oci hdfs connector

### DIFF
--- a/hdfs-connector/src/main/java/com/oracle/bmc/hdfs/BmcConstants.java
+++ b/hdfs-connector/src/main/java/com/oracle/bmc/hdfs/BmcConstants.java
@@ -224,6 +224,9 @@ public final class BmcConstants {
             = "fs.oci.emit.thread.poll.interval.seconds";
     public static final String OCI_MON_MAX_BACKLOG_BEFORE_DROP_KEY = "fs.oci.mon.max.backlog.before.drop";
 
+    // sdk circuit breaker conf
+    public static final String OBJECT_STORAGE_CLIENT_CIRCUIT_BREAKER_ENABLED_KEY = "fs.oci.client.circuitbreaker.enabled";
+
     /**
      * This class contains constants with deprecated values. The HDFS connector will first try the current values
      * in {@link com.oracle.bmc.hdfs.BmcConstants}.

--- a/hdfs-connector/src/main/java/com/oracle/bmc/hdfs/BmcProperties.java
+++ b/hdfs-connector/src/main/java/com/oracle/bmc/hdfs/BmcProperties.java
@@ -46,6 +46,13 @@ public enum BmcProperties {
      * Incompatible with READ_AHEAD.
      */
     IN_MEMORY_READ_BUFFER(IN_MEMORY_READ_BUFFER_KEY, false),
+
+    /**
+     * (boolean, optional) Flag to enable the SDK level circuit breaker.
+     * See {@link BmcConstants#OBJECT_STORAGE_CLIENT_CIRCUIT_BREAKER_ENABLED_KEY} for config key name. Default is true.
+     */
+    OBJECT_STORAGE_CLIENT_CIRCUIT_BREAKER_ENABLED(OBJECT_STORAGE_CLIENT_CIRCUIT_BREAKER_ENABLED_KEY, true),
+
     /**
      * (string, optional) Fully qualified class name of a custom implementation of {@link ObjectStorage}. See
      * {@link BmcConstants#OBJECT_STORE_CLIENT_CLASS_KEY} for config key name.

--- a/hdfs-connector/src/main/java/com/oracle/bmc/hdfs/store/BmcDataStoreFactory.java
+++ b/hdfs-connector/src/main/java/com/oracle/bmc/hdfs/store/BmcDataStoreFactory.java
@@ -53,6 +53,7 @@ import com.oracle.bmc.monitoring.MonitoringClient;
 import com.oracle.bmc.objectstorage.ObjectStorage;
 import com.oracle.bmc.objectstorage.ObjectStorageClient;
 import com.oracle.bmc.retrier.RetryConfiguration;
+import com.oracle.bmc.util.CircuitBreakerUtils;
 import com.oracle.bmc.util.StreamUtils;
 import com.oracle.bmc.util.internal.FileUtils;
 import com.oracle.bmc.util.internal.StringUtils;
@@ -290,6 +291,14 @@ public class BmcDataStoreFactory {
             clientConfigurationBuilder.readTimeoutMillis(readTimeoutMillis);
         }
 
+        final Boolean circuitBreakerEnabled =
+            propertyAccessor.asBoolean().get(BmcProperties.OBJECT_STORAGE_CLIENT_CIRCUIT_BREAKER_ENABLED);
+        if (circuitBreakerEnabled != null && !circuitBreakerEnabled) {
+            LOG.info("Setting to no-op circuit breaker conf");
+            clientConfigurationBuilder.circuitBreakerConfiguration(
+                CircuitBreakerUtils.getNoCircuitBreakerConfiguration());
+        }
+
         ClientConfiguration clientConfig = clientConfigurationBuilder.build();
         BasicAuthenticationDetailsProvider authDetailsProvider = this.createAuthenticator(propertyAccessor);
 
@@ -497,6 +506,14 @@ public class BmcDataStoreFactory {
         if (readTimeoutMillis != null) {
             LOG.info("Setting read timeout to {}", readTimeoutMillis);
             clientConfigurationBuilder.readTimeoutMillis(readTimeoutMillis);
+        }
+
+        final Boolean circuitBreakerEnabled =
+            propertyAccessor.asBoolean().get(BmcProperties.OBJECT_STORAGE_CLIENT_CIRCUIT_BREAKER_ENABLED);
+        if (circuitBreakerEnabled != null && !circuitBreakerEnabled) {
+            LOG.info("Setting to no-op circuit breaker conf");
+            clientConfigurationBuilder.circuitBreakerConfiguration(
+                CircuitBreakerUtils.getNoCircuitBreakerConfiguration());
         }
 
         // Set the retry strategy for the client


### PR DESCRIPTION
At present the circuit breaker is becoming a bottleneck neck as sometimes we see huge open values especially in the case of failure of the external systems
```
Caused by: org.apache.flink.util.SerializedThrowable: com.oracle.bmc.model.BmcException: Error returned by HeadObject operation in ObjectStorage service.(-1, null, false) CircuitBreaker has been OPEN for 11146.067 seconds and all the requests sent in a window of 30 seconds will be rejected.
```
Creating an option to disable the circuit breaker at the OCI HDFS connector level 

https://github.com/oracle/oci-java-sdk/blob/bf306d4e7d7ecad9bf5490b3efd53efae425e654/bmc-common/src/main/java/com/oracle/bmc/http/internal/CircuitBreakerHelper.java#L30 

cc : @yanhaizhongyu 