### PR TITLE
Fix thread leak by closing BmcDataStore in BmcFilesystem.close()

### DIFF
--- a/hdfs-connector/src/main/java/com/oracle/bmc/hdfs/BmcFilesystem.java
+++ b/hdfs-connector/src/main/java/com/oracle/bmc/hdfs/BmcFilesystem.java
@@ -914,6 +914,9 @@ class BmcFilesystemImpl extends FileSystem {
         try {
             super.close();
             isClosed = true;
+            if (dataStore != null) {
+                dataStore.close();
+            }
         } catch (Exception e) {
             LOG.warn("Caught exception while closing filesystem", e);
         }
@@ -980,7 +983,6 @@ class BmcFilesystemImpl extends FileSystem {
             if (resultList.size() > 0) {
                 return true;
             }
-            dataStore.close();
             if (fetchComplete) {
                 return false;
             } else {


### PR DESCRIPTION
BmcDataStore was previously closed inside hasNext(), leading to errors like task rejection 
and stopwatch misuse after shutdown. This change ensures it is closed only once in close(), 
preventing thread leaks and resource reuse issues.