### PR TITLE
Add <name> and <description> to POM for smartparquet addon

### DIFF
--- a/hdfs-addons/hdfs-smartparquet/pom.xml
+++ b/hdfs-addons/hdfs-smartparquet/pom.xml
@@ -17,6 +17,9 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>oci-hdfs-addons-smartparquet</artifactId>
+    <name>Oracle Cloud Infrastructure HDFS Connector - Smart Parquet Addon</name>
+    <description>Provides Parquet format support with footer caching for the OCI HDFS Connector.</description>
+
 
     <properties>
         <apache.parquet.version>1.11.1</apache.parquet.version>


### PR DESCRIPTION
Fix Sonatype validation issue by adding name and description to smartparquet POM